### PR TITLE
Fix typo in README: change 'longer' to 'no longer' to clarify maintenance status

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 This plugin provides a text autocomplete feature to enhance typing speed.
 
-> ⚠️ This plugin is longer maintained as I'm not using Obsidian anymore.
+> ⚠️ This plugin is no longer maintained as I'm not using Obsidian anymore.
 > 
 > I might update it in the future, but until then, please use other plugins like [Obsidian completr](https://github.com/tth05/obsidian-completr)
 


### PR DESCRIPTION
I noticed a small typo in the README and would like to submit a fix.

The current text says 'This plugin is longer maintained as I'm not using Obsidian anymore.' I believe the intended meaning is 'This plugin is no longer maintained as I'm not using Obsidian anymore.' 

I hope this change is helpful and thanks for maintaining the repository